### PR TITLE
Correct spacedust minHarvestValue

### DIFF
--- a/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/FarFutureTechnologies.cfg
+++ b/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/FarFutureTechnologies.cfg
@@ -5,7 +5,7 @@
 		HARVESTED_RESOURCE
 		{
 			Name = Graviolium
-			MinHarvestValue = 0.00000000000000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000000001
 			BaseEfficiency = 1
 		}
 	}
@@ -18,7 +18,7 @@
 		HARVESTED_RESOURCE
 		{
 			Name = Graviolium
-			MinHarvestValue = 0.00000000000000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000000001
 			BaseEfficiency = 1
 		}
 	}

--- a/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/SpaceDust.cfg
+++ b/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/SpaceDust.cfg
@@ -25,8 +25,8 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust]
 		name = KerbolGraviolium
 		title = Kerbol Graviolium Belt
 
-        	minAbundance = 0.000000000000000000000000000017        
-        	maxAbundance = 0.000000000000000000000000000020
+        minAbundance = 0.000000000000000000000000000017        
+        maxAbundance = 0.000000000000000000000000000020
 
 		alwaysDiscovered = false
 		alwaysIdentified = false
@@ -506,7 +506,7 @@ SPACEDUST_INSTRUMENT:NEEDS[SpaceDust]
 		{
 			Name = Graviolium
 			BaseEfficiency = 1.0
-			MinHarvestValue = 0.0000000001
+			MinHarvestValue = 0.0000000000000000000000000000000000000000000000001
 		}
 	}
 }

--- a/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/SpaceDust.cfg
+++ b/GameData/WildBlueIndustries/FlyingSaucers/ModuleManagerPatches/SpaceDust.cfg
@@ -25,8 +25,8 @@ SPACEDUST_RESOURCE:NEEDS[SpaceDust]
 		name = KerbolGraviolium
 		title = Kerbol Graviolium Belt
 
-        minAbundance = 0.000000000000000000000000000017        
-        maxAbundance = 0.000000000000000000000000000020
+        	minAbundance = 0.000000000000000000000000000017        
+        	maxAbundance = 0.000000000000000000000000000020
 
 		alwaysDiscovered = false
 		alwaysIdentified = false


### PR DESCRIPTION
The minHarvestValue of the spacedust harvester was higher than the maxAbundance of most graviolium belts. This patch sets the minHarvestValue extremely low, so it will work in any graviolium belt, while still not working outside a graviolium belt.

Thanks for the awesome mod!

Also, may I use my fork until this pull request is approved?